### PR TITLE
Use always latest Node.js on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 
 language: node_js
 node_js:
-  - 8
+  - node
 
 before_install:
   - npm install codecov.io coveralls


### PR DESCRIPTION
Another small fix. Current Node.js is 10.x. But Travis CI is using Node.js 8. There is no big difference, but using latest Nodejs could potentially make Travis CI work faster. Not a big deal, just small fix.

If there is a reason to use Node.js 8, you can close this PR.