### PR TITLE
Fix ESLint warnings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,13 @@
 {
-  "extends": ["react-app", "eslint:recommended"]
+  "extends": ["react-app", "eslint:recommended"],
+  "overrides": [
+    {
+      "files": [
+        "*.domtest.js"
+      ],
+      "rules": {
+        "no-console": "off"
+      }
+    }
+  ]
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ node_js:
 before_install:
   - npm install codecov.io coveralls
 
+script: yarn run lint && yarn run test
+
 after_success:
   - cat ./coverage/lcov.info | ./node_modules/codecov.io/bin/codecov.io.js
   - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "deploy-demo": "yarn run build; cp demo/dist/index.html demo/dist/200.html; surge demo/dist --domain literate-fly.surge.sh",
     "start": "nwb serve-react-demo",
     "test": "jest",
+    "lint": "eslint src *.js",
     "test:dom": "parcel mocha/testrunner.html",
     "test:all": "jest; yarn run test:dom",
     "preversion": "npm test",

--- a/src/flip/animateFlippedElements/index.js
+++ b/src/flip/animateFlippedElements/index.js
@@ -157,6 +157,7 @@ const animateFlippedElements = ({
   const body = document.querySelector("body")
 
   if (debug) {
+    // eslint-disable-next-line no-console
     console.error(
       'The "debug" prop is set to true. All FLIP animations will return at the beginning of the transition.'
     )

--- a/src/flip/getFlippedElementPositions/index.js
+++ b/src/flip/getFlippedElementPositions/index.js
@@ -100,8 +100,6 @@ export const getFlippedElementPositionsBeforeUpdate = ({
     })
     .reduce(addTupleToObject, {})
 
-  const inProgressAnimationIds = Object.keys(inProgressAnimations)
-
   // do this at the very end since we want to cache positions of elements
   // while they are mid-transition
   cancelInProgressAnimations(inProgressAnimations)


### PR DESCRIPTION
Hope I didn’t bother you with small fixes PR :D.

1. The forgotten variable was removed.
2. ESLint ignore was added to debug output.
3. `console` now is allowed in DOM tests.
4. ESLint was added to Travis CI to prevent warnings in the future.