### PR TITLE
Add Flipped component type

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -10,7 +10,7 @@ export type SpringConfig = "noWobble" | "gentle" | "wobbly" | "stiff" | Spring
 
 export type FlippedComponentIdFilter = string | any[]
 
-export interface FlippedWithContextProps {
+export interface FlippedProps {
   children: React.ReactNode
   inverseFlipId?: string
   flipId?: string
@@ -34,7 +34,7 @@ export interface FlippedWithContextProps {
   portalKey?: string
 }
 
-export const FlippedWithContext: React.SFC<FlippedWithContextProps>
+export const Flipped: React.ComponentType<FlippedProps>
 
 export interface FlipperProps {
   flipKey: any
@@ -47,6 +47,5 @@ export interface FlipperProps {
   portalKey?: string
 }
 
-export class Flipper extends React.Component<FlipperProps, any> {
-  render(): JSX.Element
-}
+export const Flipper: React.ComponentType<FlipperProps>
+


### PR DESCRIPTION
First off, thank you for this awesome library!

I have been using it in a TypeScript project and have been getting the error:
```
[ts] Module '"<rootDir>/node_modules/react-flip-toolkit/lib/index"' has no exported member 'Flipped'. Did you mean 'Flipper'?
```

It looks like `FlippedWithContextProps` exists however there isn't a `Flipped` member exported with those props.

Let me know if this is not how you would declare the types!