### PR TITLE
Updated typings file to make every 'any' explicit.

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -33,8 +33,8 @@ export interface FlippedProps {
     index: number,
     removeElement: () => any
   ) => any
-  shouldFlip?: (prevDecisionData, currentDecisionData) => boolean
-  shouldInvert?: (prevDecisionData, currentDecisionData) => boolean
+  shouldFlip?: (prevDecisionData: any, currentDecisionData: any) => boolean
+  shouldInvert?: (prevDecisionData: any, currentDecisionData: any) => boolean
   portalKey?: string
 }
 


### PR DESCRIPTION
Hi,

The props `shouldFlip` and `shouldInvert` both accept functions whose arguments are `any` according to the docs. When using TypeScript with `noImplicitAny`, it won't compile unless all `any` are implicit.

Thanks!