### PR TITLE
Fix TypeScript type definitions

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -48,7 +48,7 @@ export interface StaggerConfig {
   [key: string]: StaggerConfigValue
 }
 
-export interface handleEnterUpdateDeleteArgs {
+export interface HandleEnterUpdateDeleteArgs {
   hideEnteringElements: () => void
   animateExitingElements: () => Promise<void>
   animateFlippedElements: () => Promise<void>
@@ -65,7 +65,7 @@ export interface FlipperProps {
   className?: string
   portalKey?: string
   decisionData?: any
-  handleEnterUpdateDelete?: (handleEnterUpdateDeleteArgs) => void
+  handleEnterUpdateDelete?: (args: HandleEnterUpdateDeleteArgs) => void
   staggerConfig?: StaggerConfig
 }
 


### PR DESCRIPTION
The type of the argument for `handleEnterUpdateDelete` was defined but not being used. This prevented the use of this library if you have `noImplicitAny` (or strict mode) enabled with TypeScript, which is fairly common. This change should fix it.