### PR TITLE
Flipped component allow function as a child

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ TODO
 .cache
 dist
 stats.json
+.idea

--- a/README.md
+++ b/README.md
@@ -309,13 +309,13 @@ and in another component somewhere else you can have
 
 and they will be tweened by `react-flip-toolkit`.
 
-The `Flipped` component produces no markup, it simply passes some props down to its wrapped child. If the child is a React component, make sure it passes down unknown props directly to the rendered DOM element.
+The `Flipped` component produces no markup, it simply passes some props down to its wrapped child. If the child is a React component or a function, make sure it passes down Flipped props directly to the rendered DOM element.
 
 #### Basic props
 
 | prop                    | default    | type                  | details                                                                                                                                                                                                                                                                                                                                              |
 | ----------------------- | :--------: | :-------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| children **(required)** | -          | `node`                | Wrap a single child with the `Flipped` component.                                                                                                                                                                                                                                                                                                    |
+| children **(required)** | -          | `node` or `function`                | Wrap a single child with the `Flipped` component.                                                                                                                                                                                                                                                                                                    |
 | flipId **(required)**   | -          | `string`              | Use this to tell `react-flip-toolkit` how elements should be matched across renders so they can be animated.                                                                                                                                                                                                                                         |
 | inverseFlipId           | -          | `string`              | Refer to the id of the parent `Flipped` container whose transform you want to cancel out. [Read more about canceling out parent transforms here.](#practical-scale-transitions)                                                                                                                                                                      |
 | transformOrigin         | `"0 0"`    | `string`              | This is a convenience method to apply the proper CSS `transform-origin` to the element being FLIP-ped. This will override `react-flip-toolkit`'s default application of `transform-origin: 0 0;` if it is provided as a prop.                                                                                                                        |
@@ -402,7 +402,12 @@ That means any layout styles &mdash; padding, flexbox, etc&mdash;should be appli
 
 ### Problem #1: Nothing is happening
   - Make sure you're updating the `flipKey` attribute in the `Flipper` component whenever an animation should happen.
-  - If one of your `Flipped` components is wrapping another React component rather than a DOM element, make sure that component passes down unknown props directly to its DOM element, e.g.: `<div className="square" {...rest} />`
+  - If one of your `Flipped` components is wrapping another React component rather than a DOM element, make sure that component passes down unknown props directly to its DOM element, e.g.: `<div className="square" {...rest} />`. Or use function as a children to get Flipped props to passes down to the DOM element e.g.:
+  ```jsx
+  <Flipped>
+    {flippedProps => <MyComponent flippedProps={flippedProps} />}
+  </Flipped>
+  ```
 
 ### Problem #2: Things look weird
   - At any point, there can only be one element with a specified `flipId` on the page. If there are multiple `Flipped` elements on the page with the same id, the animation will break. Check to make sure all `flipId`s are unique.

--- a/src/Flipped.js
+++ b/src/Flipped.js
@@ -19,7 +19,7 @@ const customPropCheck = function(props, propName) {
 }
 
 const propTypes = {
-  children: PropTypes.node.isRequired,
+  children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
   inverseFlipId: customPropCheck,
   flipId: customPropCheck,
   opacity: PropTypes.bool,
@@ -44,12 +44,17 @@ export function Flipped({
   portalKey,
   ...rest
 }) {
-  let child
-  try {
-    child = Children.only(children)
-  } catch (e) {
-    throw new Error("Each Flipped component must wrap a single child")
+  let child = children
+  const isFunctionAsChildren = typeof child === 'function'
+
+  if (!isFunctionAsChildren) {
+    try {
+      child = Children.only(children)
+    } catch (e) {
+      throw new Error("Each Flipped component must wrap a single child")
+    }
   }
+
   // if nothing is being animated, assume everything is being animated
   if (!rest.scale && !rest.translate && !rest.opacity) {
     assign(rest, {
@@ -73,7 +78,7 @@ export function Flipped({
     dataAttributes[constants.DATA_PORTAL_KEY] = portalKey
   }
 
-  return cloneElement(child, dataAttributes)
+  return isFunctionAsChildren ? child(dataAttributes) : cloneElement(child, dataAttributes)
 }
 
 class FlippedWithContext extends Component {

--- a/src/__tests__/Flipped.test.js
+++ b/src/__tests__/Flipped.test.js
@@ -94,4 +94,17 @@ describe("Flipped Component", () => {
   describe("spring props", () => {
     it("if it detects the ", () => {})
   })
+
+  it("passed props if function as a child", () => {
+    const testRenderer = TestRenderer.create(
+      <Flipped flipId="foo" inverseFlipId="bar">
+        {(flippedProps => <div {...flippedProps} />)}
+      </Flipped>
+    )
+    expect(testRenderer.toJSON().props).toEqual({
+      'data-flip-id': 'foo',
+      'data-inverse-flip-id': 'bar',
+      'data-flip-config': JSON.stringify({ translate: true, scale: true, opacity: true })
+    });
+  });
 })


### PR DESCRIPTION
First off, thank you for this awesome library!

This PR make Flipped component allow function as a child.

Why?
Currently, the documentation said
>If one of your Flipped components is wrapping another React component rather than a DOM element, make sure that component passes down unknown props directly to its DOM element

The problem is `passes down unknown props` may cause React warning about invalid prop.

How is it look?
```jsx
const MyComponent = ({ flipProps }) => (
  <div {...flipProps}>Something here</div>
);

<Flipped flipId="foo">
  {flipProps => <MyComponent flipProps={flipProps} />}
</Flipped>
```