### PR TITLE
Expose "shouldInvert" field in addFlipped func

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -87,7 +87,8 @@ class Flipper {
     onStart,
     onComplete,
     onExit,
-    shouldFlip
+    shouldFlip,
+    shouldInvert
   }: FlippedProps & { element: HTMLElement }) {
     if (!element) {
       throw new Error('no element provided')
@@ -117,6 +118,7 @@ class Flipper {
     // finally, add callbacks
     this.flipCallbacks[flipId] = {
       shouldFlip,
+      shouldInvert,
       onAppear,
       onStart,
       onComplete,


### PR DESCRIPTION
After further investigation into https://github.com/aholachek/react-flip-toolkit/issues/67, it looks like being able to pass a custom `shouldInvert` function to `addFlipped` is a feasible workaround to not having access to the `decisionData` field when instantiating a `Flipper`.

Please let me know if there are any questions – I'm happy to expand on my use case.