### PR TITLE
Expose decisionData as arguments to onUpdate

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -54,7 +54,7 @@ class Flipper {
       inProgressAnimations: this.inProgressAnimations
     })
   }
-  onUpdate() {
+  onUpdate(prevDecisionData, currentDecisionData) {
     if (this.snapshot) {
       onFlipKeyUpdate({
         flippedElementPositionsBeforeUpdate: this.snapshot
@@ -68,7 +68,11 @@ class Flipper {
         debug: this.debug,
         staggerConfig: this.staggerConfig,
         handleEnterUpdateDelete: this.handleEnterUpdateDelete,
-        retainTransform: this.retainTransform
+        retainTransform: this.retainTransform,
+        decisionData: {
+          prev: prevDecisionData,
+          current: currentDecisionData
+        }
       })
       delete this.snapshot
     }


### PR DESCRIPTION
Hello! I wanted to get your thoughts on the following tweak to the `onUpdate` function from the core library.

## Context
For [`vue-flip-toolkit`](https://github.com/mattrothenberg/vue-flip-toolkit), I'm using a Vue-specific feature called a [watcher](https://vuejs.org/v2/guide/computed.html#Watchers) to determine when to call the `onUpdate` func from your core library. It's akin to `componentDidUpdate`, except that you're focused on a single prop at a time, instead of `this.props` vs. `prevProps`.

So, essentially, when the parent `Flipper` component receives a new `flipKey` prop, it triggers the `onUpdate` func and everything works magically.

```js
// Flipper.vue
watch: {
  flipKey(newKey, oldKey) {
    if (newKey !== oldKey) {
      this.$nextTick(() => {
        this.flipInstance.onUpdate();
      });
    }
  }
}
```

## The Question(s)
I observed in https://github.com/aholachek/react-flip-toolkit/issues/67 that we can't yet pass any `decisionData` to the `onUpdate` func in core, meaning that we have to track the decision state (current/prev) at the component level, on a per-instance basis. This works fine, particularly now that consumers have control over the `shouldInvert` and `shouldFlip` functions.

I'm curious, though, whether the tweak in this PR – exposing two new arguments to the `onUpdate` func, `prevDecisionData` and `currentDecisionData` – is an additional enhancement that will make 3rd party usage of this library easier. For instance, this unlocks the following usage in my library.

```js
// Flipper.vue
watch: {
  flipKey(newKey, oldKey) {
    if (newKey !== oldKey) {
      this.$nextTick(() => {
        this.flipInstance.onUpdate(oldKey, newKey); // 😍 
      });
    }
  }
}
```
```js
// RandomConsumerOfVueFlipToolkit.vue
methods: {
  shouldFlip(index) {
    return (prev, current) => {
      // Now, prev and current correspond
      // to the arguments passed to onUpdate.

      // Previously, this Vue component had to cache
      // the "prev" value in order to perform this computation

      return index === prev || index === current;
    };
  }
}
```
For now, I'm not allowing consumers of the `Flipper.vue` component to pass custom `decisionData`. I'm making an assumption (right or wrong) that the value of `decisionData` will more often than not correspond with the value being passed as the `flipKey` of the `Flipper` instance. 🤷‍♂️ 

I hope that makes sense. To put a finer point on it, I'm curious how we can expose `decisionData` to users of the Core API.

Happy to clarify any way I can.