### PR TITLE
Adds a small note to README about elements that aren't visible in the DOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,7 +478,8 @@ square.addEventListener("click", () => {
 ### Problem #1: Nothing is happening
   - Make sure you're updating the `flipKey` attribute in the `Flipper` component whenever an animation should happen.
   - If one of your `Flipped` components is wrapping another React component rather than a DOM element,  [use a render prop to get the Flipped props](#wrapping-a-react-component) and pass down to the necessary DOM element.
-
+  - Is the element that's receiving props from `Flipped` visible in the DOM? `react-flip-toolkit` attempts to optimize performance by not animating elements that are off-screen or elements that have no width or height.
+  
 ### Problem #2: Things look weird
   - At any point, there can only be one element with a specified `flipId` on the page. If there are multiple `Flipped` elements on the page with the same id, the animation will break. Check to make sure all `flipId`s are unique.
   - Make sure you are animating the element you want to animate and not, for instance, a wrapper div. If you are animating an inline element like some text, but have wrapped it in a `div`, you're actually animating the div, which might have a much wider width that you'd expect at certain points, which will throw off the animation. Check to see if you need to add an  `inline-block` style to the animated element.


### PR DESCRIPTION
Thank you so much for `react-flip-toolkit`. It makes creating awesome UI animations in the browser so much simpler and less complicated.

I ran into a small problem while upgrading a dependency from v4 to the most recent version a few weeks ago. A flip animation was breaking and I couldn't figure out why. The problem turned out to be the `div` receiving props from `Flipped` wasn't being animated because it had no dimension (it was absolutely positioned and had no explicit dimensions set to it). This was simply fixed by added adding explicit dimensions to the element.

This is probably an edge case, but for the sake of posterity I thought I'd add what I learned to the docs here for any future users who might come across this problem in the future.