### PR TITLE
Bugfix issue 73: animation stop when element inside iframe

### DIFF
--- a/src/flip/animateFlippedElements/index.ts
+++ b/src/flip/animateFlippedElements/index.ts
@@ -163,7 +163,8 @@ export default ({
   scopedSelector,
   retainTransform
 }: AnimateFlippedElementsArgs) => {
-  const body = document.querySelector('body')!
+  const firstElement: HTMLElement = getElement(flippedIds[0])
+  const body = firstElement.ownerDocument!.querySelector('body')!
 
   // the stuff below is used so we can return a promise that resolves when all FLIP animations have
   // completed


### PR DESCRIPTION
Animation breaks if flipped element inside iframe
This fix changes animateFlippedElements function to check not `document.body` but `element.ownerDocument.body` which is correct body for iframes descendants