### PR TITLE
feat: parallel animations

### DIFF
--- a/packages/react-flip-toolkit/src/FlipToolkit/flip/index.ts
+++ b/packages/react-flip-toolkit/src/FlipToolkit/flip/index.ts
@@ -72,7 +72,8 @@ const onFlipKeyUpdate = ({
   decisionData = {},
   handleEnterUpdateDelete,
   onComplete,
-  onStart
+  onStart,
+  chainExitingEntering = true
 }: OnFlipKeyUpdateArgs) => {
 
   const flippedElementPositionsAfterUpdate = getFlippedElementPositionsAfterUpdate(
@@ -146,7 +147,12 @@ const onFlipKeyUpdate = ({
     })
   } else {
     hideEnteringElements()
-    animateExitingElements().then(animateEnteringElements)
+    if (chainExitingEntering) {
+      animateExitingElements().then(animateEnteringElements)
+    } else {
+      animateExitingElements()
+      animateEnteringElements()
+    }
     flip()
   }
 }

--- a/packages/react-flip-toolkit/src/FlipToolkit/flip/types.ts
+++ b/packages/react-flip-toolkit/src/FlipToolkit/flip/types.ts
@@ -40,4 +40,5 @@ export interface OnFlipKeyUpdateArgs {
   onComplete?: OnFlipperComplete
   onStart?: OnFlipperStart
   decisionData: DecisionData
+  chainExitingEntering?: boolean
 }


### PR DESCRIPTION
For a recent project I needed to play both entering and exiting animation at the same time (I use flip-toolkit directly). I added a new option `chainExitingEntering` (default to `true` to keep the old behaviour by default) that toggle parallel or chained animations.