### PR TITLE
Pass all given props to Flipper component

### DIFF
--- a/packages/react-flip-toolkit/src/Flipper/index.tsx
+++ b/packages/react-flip-toolkit/src/Flipper/index.tsx
@@ -64,15 +64,14 @@ class Flipper extends Component<FlipperProps> {
   }
 
   public render() {
-    const { element, className, portalKey } = this.props
-    const Element = element
+    const { element: Element, portalKey, ...other } = this.props
 
     let flipperMarkup = (
       <FlipContext.Provider value={this.flipCallbacks}>
         {/*
         // @ts-ignore */}
         <Element
-          className={className}
+          {...other}
           ref={(el: HTMLElement) => (this.el = el)}
         >
           {this.props.children}


### PR DESCRIPTION
Small change to pass along all other given props of `Flipper` to the created element.

I'm not sure why this wasn't the case already. My use case is to pass things such as `role`, `data` and `aria` attributes to the created `div` instead of having to create yet another nested `div` with the proper attributes.