### PR TITLE
Specify types file in exports field

### DIFF
--- a/packages/react-flip-toolkit/package.json
+++ b/packages/react-flip-toolkit/package.json
@@ -7,7 +7,10 @@
   "main": "lib/index.js",
   "module": "lib/index.es.js",
   "types": "lib/index.d.ts",
-  "exports": "./lib/index.modern.mjs", 
+  "exports": {
+    "default": "./lib/index.modern.mjs",
+    "types": "./lib/index.d.ts"
+  },
   "amdName": "ReactFlipToolkit",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Attempt to address https://github.com/aholachek/react-flip-toolkit/issues/224

Using this helpful website I can see the [types were correct for v7.1.0](https://arethetypeswrong.github.io/?p=react-flip-toolkit%407.1.0) but [not for v7.2.0](https://arethetypeswrong.github.io/?p=react-flip-toolkit%407.2.0)

I didn't change anything about the bundler (microbundle) in the recent minor update but I did upgrade Typescript and I wonder if that could have caused the problem based on my readings of [issues like this one.](https://github.com/microsoft/TypeScript/issues/46334). In any case this seems like a safe change so I will make a beta release and test to see if it fixes the issue.