### PR TITLE
refactor: Add explicit file paths/extensions to all source files in flip-toolkit to appease TS

### DIFF
--- a/packages/flip-toolkit/package.json
+++ b/packages/flip-toolkit/package.json
@@ -8,6 +8,10 @@
   "umd:main": "lib/index.umd.js",
   "module": "lib/index.es.js",
   "types": "./lib/index.d.ts",
+  "exports": {
+    "types": "./lib/index.d.mts",
+    "import": "./lib/index.modern.mjs"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/aholachek/react-flip-toolkit"
@@ -24,7 +28,7 @@
     "npm": ">=5"
   },
   "scripts": {
-    "build": "microbundle --name=FlipToolkit --define process.env.NODE_ENV=production --globals rematrix=Rematrix",
+    "build": "microbundle --name=FlipToolkit --define process.env.NODE_ENV=production --globals rematrix=Rematrix && cp lib/index.d.ts lib/index.d.mts",
     "build:debug": "microbundle --name=FlipToolkit --no-compress",
     "lint": "echo \"noop\"",
     "test": "echo \"noop\"",

--- a/packages/flip-toolkit/src/Flipper.ts
+++ b/packages/flip-toolkit/src/Flipper.ts
@@ -1,6 +1,6 @@
-import { onFlipKeyUpdate } from './flip'
-import getFlippedElementPositionsBeforeUpdate from './flip/getFlippedElementPositions/getFlippedElementPositionsBeforeUpdate'
-import { assign } from './utilities'
+import { onFlipKeyUpdate } from './flip/index.js'
+import getFlippedElementPositionsBeforeUpdate from './flip/getFlippedElementPositions/getFlippedElementPositionsBeforeUpdate/index.js'
+import { assign } from './utilities/index.js'
 import {
   StaggerConfig,
   HandleEnterUpdateDelete,
@@ -9,10 +9,10 @@ import {
   OnFlipperComplete,
   FlippedProps,
   OnFlipperStart
-} from './types'
-import { SpringOption } from './springSettings/types'
-import { FlippedElementPositionsBeforeUpdate } from './flip/getFlippedElementPositions/getFlippedElementPositionsBeforeUpdate/types'
-import { FlippedIds } from './flip/types'
+} from './types.js'
+import { SpringOption } from './springSettings/types.js'
+import { FlippedElementPositionsBeforeUpdate } from './flip/getFlippedElementPositions/getFlippedElementPositionsBeforeUpdate/types.js'
+import { FlippedIds } from './flip/types.js'
 
 interface Options {
   element: HTMLElement

--- a/packages/flip-toolkit/src/Spring/index.ts
+++ b/packages/flip-toolkit/src/Spring/index.ts
@@ -1,10 +1,10 @@
 // this is exclusively for users of the library to create their own enter + exit animations
-import { SpringSystem } from '../forked-rebound'
-import { SpringSystemInterface } from '../forked-rebound/types.d'
-import { tweenProp, assign } from '../utilities'
-import { normalizeSpring, springPresets } from '../springSettings'
-import { SimpleSpringOptions } from './types'
-import { SpringConfig } from '../springSettings/types'
+import { SpringSystem } from '../forked-rebound/index.js'
+import { SpringSystemInterface } from '../forked-rebound/types.js'
+import { tweenProp, assign } from '../utilities/index.js'
+import { normalizeSpring, springPresets } from '../springSettings/index.js'
+import { SimpleSpringOptions } from './types.js'
+import { SpringConfig } from '../springSettings/types.js'
 
 // this should get created only 1x
 const springSystem: SpringSystemInterface = new SpringSystem()

--- a/packages/flip-toolkit/src/Spring/types.ts
+++ b/packages/flip-toolkit/src/Spring/types.ts
@@ -1,4 +1,4 @@
-import { SpringOption } from '../springSettings/types'
+import { SpringOption } from '../springSettings/types.js'
 
 type TweenStart = number
 type TweenEnd = number

--- a/packages/flip-toolkit/src/flip/animateFlippedElements/index.ts
+++ b/packages/flip-toolkit/src/flip/animateFlippedElements/index.ts
@@ -1,5 +1,5 @@
 import * as Rematrix from 'rematrix'
-import { getSpringConfig } from '../../springSettings'
+import { getSpringConfig } from '../../springSettings/index.js'
 import {
   toArray,
   isFunction,
@@ -7,8 +7,8 @@ import {
   getDuplicateValsAsStrings,
   assign,
   tweenProp
-} from '../../utilities'
-import * as constants from '../../constants'
+} from '../../utilities/index.js'
+import * as constants from '../../constants.js'
 import {
   GetOnUpdateFunc,
   OnUpdate,
@@ -19,12 +19,12 @@ import {
   FlipDataArray,
   FlipData,
   InitializeFlip
-} from './types'
-import { BoundingClientRect } from '../getFlippedElementPositions/types'
-import { FlippedIds } from '../types'
-import { createSpring, createStaggeredSprings } from './spring'
-import { IndexableObject } from '../../utilities/types'
-import { FlipId } from '../../types'
+} from './types.js'
+import { BoundingClientRect } from '../getFlippedElementPositions/types.js'
+import { FlippedIds } from '../types.js'
+import { createSpring, createStaggeredSprings } from './spring/index.js'
+import { IndexableObject } from '../../utilities/types.js'
+import { FlipId } from '../../types.js'
 
 // 3d transforms were causing weird issues in chrome,
 // especially when opacity was also being tweened,

--- a/packages/flip-toolkit/src/flip/animateFlippedElements/spring/index.ts
+++ b/packages/flip-toolkit/src/flip/animateFlippedElements/spring/index.ts
@@ -1,10 +1,10 @@
-import { SpringSystem } from '../../../forked-rebound'
-import { StaggerConfigValue } from '../../../types'
-import { FlipData, FlipDataArray } from '../types'
+import { SpringSystem } from '../../../forked-rebound/index.js'
+import { StaggerConfigValue } from '../../../types.js'
+import { FlipData, FlipDataArray } from '../types.js'
 import {
   SpringSystemInterface,
   AddListenerArgs
-} from '../../../forked-rebound/types'
+} from '../../../forked-rebound/types.js'
 
 // this should get created only 1x
 const springSystem: SpringSystemInterface = new SpringSystem()

--- a/packages/flip-toolkit/src/flip/animateFlippedElements/types.ts
+++ b/packages/flip-toolkit/src/flip/animateFlippedElements/types.ts
@@ -1,8 +1,8 @@
-import { BaseFlipArgs, FlippedIds } from '../types'
-import { SpringOption, SpringConfig } from '../../springSettings/types'
-import { StaggerConfig, OnFlipperComplete, FlipId } from '../../types'
-import { SerializableFlippedProps } from '../../types'
-import { Spring } from '../../forked-rebound/types'
+import { BaseFlipArgs, FlippedIds } from '../types.js'
+import { SpringOption, SpringConfig } from '../../springSettings/types.js'
+import { StaggerConfig, OnFlipperComplete, FlipId } from '../../types.js'
+import { SerializableFlippedProps } from '../../types.js'
+import { Spring } from '../../forked-rebound/types.js'
 
 export type ScopedSelector = (selector: string) => HTMLElement[]
 

--- a/packages/flip-toolkit/src/flip/animateUnflippedElements/index.ts
+++ b/packages/flip-toolkit/src/flip/animateUnflippedElements/index.ts
@@ -1,4 +1,4 @@
-import { AnimateUnflippedElementsArgs, FragmentTuple } from './types'
+import { AnimateUnflippedElementsArgs, FragmentTuple } from './types.js'
 
 const animateUnflippedElements = ({
   unflippedIds,

--- a/packages/flip-toolkit/src/flip/animateUnflippedElements/types.ts
+++ b/packages/flip-toolkit/src/flip/animateUnflippedElements/types.ts
@@ -1,4 +1,4 @@
-import { BaseFlipArgs } from '../types'
+import { BaseFlipArgs } from '../types.js'
 
 export interface AnimateUnflippedElementsArgs extends BaseFlipArgs {
   unflippedIds: string[]

--- a/packages/flip-toolkit/src/flip/getFlippedElementPositions/getFlippedElementPositionsAfterUpdate/index.ts
+++ b/packages/flip-toolkit/src/flip/getFlippedElementPositions/getFlippedElementPositionsAfterUpdate/index.ts
@@ -1,8 +1,8 @@
-import { addTupleToObject, getRects, getAllElements } from '../utilities'
+import { addTupleToObject, getRects, getAllElements } from '../utilities.js'
 import {
   FlippedElementPositionsAfterUpdate,
   FlippedElementPositionDatumAfterUpdate
-} from './types'
+} from './types.js'
 
 const getFlippedElementPositionsAfterUpdate = ({
   element,

--- a/packages/flip-toolkit/src/flip/getFlippedElementPositions/getFlippedElementPositionsAfterUpdate/types.ts
+++ b/packages/flip-toolkit/src/flip/getFlippedElementPositions/getFlippedElementPositionsAfterUpdate/types.ts
@@ -1,4 +1,4 @@
-import { BaseFlippedElementPositions } from '../types'
+import { BaseFlippedElementPositions } from '../types.js'
 
 export interface FlippedElementPositionDatumAfterUpdate
   extends BaseFlippedElementPositions {

--- a/packages/flip-toolkit/src/flip/getFlippedElementPositions/getFlippedElementPositionsBeforeUpdate/index.ts
+++ b/packages/flip-toolkit/src/flip/getFlippedElementPositions/getFlippedElementPositionsBeforeUpdate/index.ts
@@ -1,6 +1,6 @@
-import { addTupleToObject, getAllElements, getRects } from '../utilities'
-import * as constants from '../../../constants'
-import { toArray, assign } from '../../../utilities'
+import { addTupleToObject, getAllElements, getRects } from '../utilities.js'
+import * as constants from '../../../constants.js'
+import { toArray, assign } from '../../../utilities/index.js'
 import {
   FlippedElementPositionsBeforeUpdateReturnVals,
   FlippedElementPositionDatumBeforeUpdate,
@@ -8,8 +8,8 @@ import {
   ParentBCRs,
   ChildIdsToParentBCRs,
   ChildIdsToParents
-} from './types'
-import { InProgressAnimations } from '../../../types'
+} from './types.js'
+import { InProgressAnimations } from '../../../types.js'
 
 export const cancelInProgressAnimations = (
   inProgressAnimations: InProgressAnimations,

--- a/packages/flip-toolkit/src/flip/getFlippedElementPositions/getFlippedElementPositionsBeforeUpdate/types.ts
+++ b/packages/flip-toolkit/src/flip/getFlippedElementPositions/getFlippedElementPositionsBeforeUpdate/types.ts
@@ -1,5 +1,5 @@
-import { BoundingClientRect, BaseFlippedElementPositions } from '../types'
-import { InProgressAnimations, FlipCallbacks, FlipId } from '../../../types'
+import { BoundingClientRect, BaseFlippedElementPositions } from '../types.js'
+import { InProgressAnimations, FlipCallbacks, FlipId } from '../../../types.js'
 
 export interface DomDataForExitAnimations {
   element: HTMLElement

--- a/packages/flip-toolkit/src/flip/getFlippedElementPositions/utilities.ts
+++ b/packages/flip-toolkit/src/flip/getFlippedElementPositions/utilities.ts
@@ -1,6 +1,6 @@
-import { toArray, assign } from '../../utilities'
-import * as constants from '../../constants'
-import { BoundingClientRect } from './types'
+import { toArray, assign } from '../../utilities/index.js'
+import * as constants from '../../constants.js'
+import { BoundingClientRect } from './types.js'
 
 export const addTupleToObject = <T>(
   acc: Record<string, T>,

--- a/packages/flip-toolkit/src/flip/index.ts
+++ b/packages/flip-toolkit/src/flip/index.ts
@@ -1,19 +1,19 @@
-import animateUnflippedElements from './animateUnflippedElements'
-import animateFlippedElements from './animateFlippedElements'
-import getFlippedElementPositionsAfterUpdate from './getFlippedElementPositions/getFlippedElementPositionsAfterUpdate'
-import * as constants from '../constants'
-import { assign, toArray } from '../utilities'
+import animateUnflippedElements from './animateUnflippedElements/index.js'
+import animateFlippedElements from './animateFlippedElements/index.js'
+import getFlippedElementPositionsAfterUpdate from './getFlippedElementPositions/getFlippedElementPositionsAfterUpdate/index.js'
+import * as constants from '../constants.js'
+import { assign, toArray } from '../utilities/index.js'
 import {
   GetElement,
   BaseFlipArgs,
   OnFlipKeyUpdateArgs,
   FlippedIds
-} from './types'
-import { AnimateUnflippedElementsArgs } from './animateUnflippedElements/types'
+} from './types.js'
+import { AnimateUnflippedElementsArgs } from './animateUnflippedElements/types.js'
 import {
   AnimateFlippedElementsArgs,
   ScopedSelector
-} from './animateFlippedElements/types'
+} from './animateFlippedElements/types.js'
 
 let enabled = true
 

--- a/packages/flip-toolkit/src/flip/types.ts
+++ b/packages/flip-toolkit/src/flip/types.ts
@@ -6,11 +6,11 @@ import {
   OnFlipperComplete,
   OnFlipperStart,
   DecisionData
-} from '../types'
-import { FlippedElementPositionsBeforeUpdate } from './getFlippedElementPositions/getFlippedElementPositionsBeforeUpdate/types'
-import { FlippedElementPositionsAfterUpdate } from './getFlippedElementPositions/getFlippedElementPositionsAfterUpdate/types'
-import { CachedOrderedFlipIds } from './getFlippedElementPositions/getFlippedElementPositionsBeforeUpdate/types'
-import { SpringOption } from '../springSettings/types'
+} from '../types.js'
+import { FlippedElementPositionsBeforeUpdate } from './getFlippedElementPositions/getFlippedElementPositionsBeforeUpdate/types.js'
+import { FlippedElementPositionsAfterUpdate } from './getFlippedElementPositions/getFlippedElementPositionsAfterUpdate/types.js'
+import { CachedOrderedFlipIds } from './getFlippedElementPositions/getFlippedElementPositionsBeforeUpdate/types.js'
+import { SpringOption } from '../springSettings/types.js'
 
 export type FlippedIds = string[]
 

--- a/packages/flip-toolkit/src/index.ts
+++ b/packages/flip-toolkit/src/index.ts
@@ -1,7 +1,7 @@
-import * as utilities from './utilities'
-import * as constants from './constants'
-export { default as Flipper } from './Flipper'
-export { default as getFlippedElementPositionsBeforeUpdate } from './flip/getFlippedElementPositions/getFlippedElementPositionsBeforeUpdate'
-export * from './flip'
+import * as utilities from './utilities/index.js'
+import * as constants from './constants.js'
+export { default as Flipper } from './Flipper.js'
+export { default as getFlippedElementPositionsBeforeUpdate } from './flip/getFlippedElementPositions/getFlippedElementPositionsBeforeUpdate/index.js'
+export * from './flip/index.js'
 export { utilities, constants }
-export { default as spring } from './Spring'
+export { default as spring } from './Spring/index.js'

--- a/packages/flip-toolkit/src/springSettings/index.ts
+++ b/packages/flip-toolkit/src/springSettings/index.ts
@@ -1,5 +1,5 @@
-import { isObject, assign } from '../utilities'
-import { SpringPresets, SpringConfig, SpringOption } from './types'
+import { isObject, assign } from '../utilities/index.js'
+import { SpringPresets, SpringConfig, SpringOption } from './types.js'
 
 // adapted from
 // https://github.com/chenglou/react-motion/blob/master/src/presets.js

--- a/packages/flip-toolkit/src/springSettings/types.ts
+++ b/packages/flip-toolkit/src/springSettings/types.ts
@@ -1,4 +1,4 @@
-import { IndexableObject } from '../utilities/types'
+import { IndexableObject } from '../utilities/types.js'
 
 export interface SpringConfig {
   stiffness?: number

--- a/packages/flip-toolkit/src/types.ts
+++ b/packages/flip-toolkit/src/types.ts
@@ -1,5 +1,5 @@
-import { SpringOption } from './springSettings/types'
-export type { FlippedElementPositionsBeforeUpdateReturnVals } from './flip/getFlippedElementPositions/getFlippedElementPositionsBeforeUpdate/types'
+import { SpringOption } from './springSettings/types.js'
+export type { FlippedElementPositionsBeforeUpdateReturnVals } from './flip/getFlippedElementPositions/getFlippedElementPositionsBeforeUpdate/types.js'
 
 export type FlipId = string | number
 

--- a/packages/flip-toolkit/src/utilities/index.ts
+++ b/packages/flip-toolkit/src/utilities/index.ts
@@ -1,4 +1,4 @@
-import { IndexableObject } from './types'
+import { IndexableObject } from './types.js'
 
 export const isNumber = (x: any) => typeof x === 'number'
 


### PR DESCRIPTION
Following up from https://github.com/developit/microbundle/issues/1085

Absolutely feel free to discard this -- it's a big change and reaches into coding style/preference a bit. This is essentially what's necessary. With this change, TS outputs "ESM `.d.ts`" files which has correct file paths.

The best way to test this that I've found is to switch the `"moduleResolution"` of the `tsconfig.json` to `"node16"` and also add `"type": "module"` in the `package.json`. There might be another way to get TS to surface errors, not quite sure. I imagine there's an ESLint plugin that could help enforce this too.

Running `yarn build && npm pack` generates a tarball that https://arethetypeswrong.github.io/ seems to give a thumbs-up for.